### PR TITLE
Note that we now need gulp-cli globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Pre-requisites:
 - node (v8+)
 - npm (v5+)
 - bower
-- gulp (v4+)
+- gulp-cli (v4+). Run `npm install --global gulp-cli`. See https://github.com/gulpjs/gulp/blob/master/docs/getting-started/1-quick-start.md for details.
 
 To setup:
 


### PR DESCRIPTION
Instead of gulp. See the link included in the README for more
information. I got an error when I used my global gulp:

```
    gulpInst.start.apply(gulpInst, toRun);
                  ^

    TypeError: Cannot read property 'apply' of undefined
```