### PR TITLE
Fix endless image errors

### DIFF
--- a/src/mlvisjs.global.js
+++ b/src/mlvisjs.global.js
@@ -67,9 +67,7 @@ var mlvisjs = (function () {
       borderWidth: 2,
       shadow: true,
       borderWidthSelected: 6,
-      shape: 'circularImage',
-      brokenImage: 'dist/images/generic.png',
-      image: 'images/generic.png',
+      shape: 'dot',
       color: {
         background: 'white',
       },

--- a/src/mlvisjs.global.js
+++ b/src/mlvisjs.global.js
@@ -67,9 +67,8 @@ var mlvisjs = (function () {
       borderWidth: 2,
       shadow: true,
       borderWidthSelected: 6,
-      shape: 'dot',
       color: {
-        background: 'white',
+        background: 'white'
       },
       font: {
         size: 12


### PR DESCRIPTION
With the current setup, `dist/images/generic.png` is not available in my
React app. I tried prepending the `node_modules` path, which also
failed.

It fails rather spectacularly, quickly generating tens of thousands of
failed network requests and console errors, eventually crashing the tab.
I think it is the issue referenced here:
https://github.com/almende/vis/issues/3338

I found that removing the `brokenImage` property worked. The nodes just
look like circles.

It would be better to figure out a framework-agnostic way to include images, but I'm not sure how to do that, and in the meantime, better to patch this issue. How did you do it in Vue? Did you set up custom image paths in the consuming app?